### PR TITLE
Codex Improvements: quero um settings que tambem consiga ler da raiz d...

### DIFF
--- a/src/configs/settings.py
+++ b/src/configs/settings.py
@@ -1,5 +1,8 @@
+import os
+from pathlib import Path
 from pydantic_settings import BaseSettings
-from pydantic import Field 
+from pydantic import Field
+import yaml
 
 
 class Settings(BaseSettings):
@@ -9,21 +12,36 @@ class Settings(BaseSettings):
     openai_model: str = Field(
         default="gpt-4o-mini",
     )
-    
+
     prompt_template: str = Field(
         default="você deve detectar as emoçoes contidas na {message} de"
         " acordo com as {format_instructions} e deve ser em portugues brasileiro",
     )
-    
+
     @classmethod
     def from_yaml(cls, file_path: str):
         """
         Load settings from a YAML file.
         """
-        import yaml
-        with open(file_path, 'r') as file:
+        with open(file_path, "r", encoding="utf-8") as file:
             data = yaml.safe_load(file)
         return cls(**data)
 
+    @classmethod
+    def from_env_yaml(cls, filename: str = ".env.yaml"):
+        """
+        Load settings from a YAML file located at the project root.
+        If the file does not exist, fallback to default settings.
+        """
+        root_path = Path(__file__).parent.parent.parent.resolve()
+        env_yaml_path = root_path / filename
+        if env_yaml_path.exists():
+            with open(env_yaml_path, "r", encoding="utf-8") as file:
+                data = yaml.safe_load(file) or {}
+            return cls(**data)
+        else:
+            return cls()
 
-settings = Settings()
+
+# Prefer loading from .env.yaml at project root for textual configs like prompt templates
+settings = Settings.from_env_yaml()


### PR DESCRIPTION

            # Codex Code Improvements

            **Query:** quero um settings que tambem consiga ler da raiz do projeto um '.env.yaml' vai servir para configurações mais textuais de llms, como prompt templates e etc

            ## Changes Applied (1)
        ### 📝 src/configs/settings.py
- Refatora a classe Settings para incluir um método from_env_yaml que carrega configurações de um arquivo .env.yaml na raiz do projeto, com fallback para valores padrão. Melhora a legibilidade, adiciona encoding na leitura de arquivos para evitar problemas com caracteres especiais, e centraliza a lógica de carregamento de configurações textuais (como prompt_template) no .env.yaml, conforme solicitado.
- Lines: 1-27


---
*Generated by Codex Agent*